### PR TITLE
Fix: Add a 'min' function to work with go1.18.1

### DIFF
--- a/utility/application.go
+++ b/utility/application.go
@@ -13,6 +13,13 @@ const (
 	SAMPLE          = 10240
 )
 
+func min(a, b int) int {
+    if a < b {
+        return a
+    }
+    return b
+}
+
 func SendMessage(input string, client string) {
 	conn, err := net.Dial(CONN_TYPE, client)
 	if err != nil {


### PR DESCRIPTION
On Ubuntu 22.04, the default go version is 1.18.1, which doesn't have "min" in the standard library.

The usual fix is to add a local definition, which I've done here.  Everything else compiles, and seems to work fine as far as I can test.